### PR TITLE
Handle NaN / masked observations

### DIFF
--- a/GCEm/abc_sampler.py
+++ b/GCEm/abc_sampler.py
@@ -152,6 +152,8 @@ def constrain(implausibility, tolerance=0., threshold=3.0):
     threshold = tf.constant(threshold, dtype=implausibility.dtype)
 
     # Count the number of implausible observations against the threshold
+    #  Note that the tf.greater comparison will return False for any NaN implausibilities,
+    #  hence NaN observations are always plausible.
     n_implausible = tf.reduce_sum(tf.cast(tf.greater(implausibility, threshold), dtype=implausibility.dtype),
                                   # Reduce over all dims except the first
                                   axis=(range(1, len(implausibility.shape))))

--- a/GCEm/abc_sampler.py
+++ b/GCEm/abc_sampler.py
@@ -8,6 +8,8 @@ class ABCSampler(Sampler):
     """
     Sample from the posterior using Approximate Bayesian Computation (ABC).
      This is a style of rejection sampling.
+
+    Note that emulator samples compared to NaN observations are always treated as 'plausible'.
     """
 
     def sample(self, prior_x=None, n_samples=1, tolerance=0., threshold=3.):

--- a/GCEm/sampler.py
+++ b/GCEm/sampler.py
@@ -169,10 +169,10 @@ def _target_log_likelihood(prior_x, x, diff, total_sd):
     good_diffs = tf.logical_not(tf.math.is_nan(diff))
     clean_diffs = tf.boolean_mask(diff, good_diffs)
     # Also apply the mask to the SDs in case they are for each obs
-    # Ignore the annoying edge case with arrays of shape (1,) which get squezed to scalars
+    # Ignore the annoying edge case with arrays of shape (1,) which get squeezed to scalars
     if good_diffs.shape != (1,):
         good_diffs = tf.squeeze(good_diffs)
-        total_sd = tf.squeeze(total_sd)  # If the diff isn't shape (1) then the SD shouldn't be either
+        total_sd = tf.squeeze(total_sd)  # If the diff isn't shape (1,) then the SD shouldn't be either
     clean_sd = tf.boolean_mask(total_sd, good_diffs)
 
     # I think creating the distributions inside the tf_function is slowing down the sampling, but I can't

--- a/tests/test_abc_sampler.py
+++ b/tests/test_abc_sampler.py
@@ -304,7 +304,9 @@ class TestABCSampler:
 
         implausibility = np.asarray([[0., 0., 0., 0., 0.],
                                      [0., 1., 1., 1., 0.],
-                                     [0., 0., 1., 0., 0.]])
+                                     [0., 0., 1., np.NaN, 0.]])
+        # Note that the NaN should be ignored for the following calculations
+
         assert_array_equal(constrain(implausibility, tolerance=0., threshold=3.0),
                            np.asarray([True, True, True]))
         assert_array_equal(constrain(implausibility, tolerance=0., threshold=0.5),
@@ -322,7 +324,7 @@ class TestABCSampler:
 
         implausibility = np.asarray([[[0., 0., 0., 0., 0.],
                                      [0., 1., 1., 1., 0.],
-                                     [0., 0., 1., 0., 0.]],
+                                     [0., 0., 1., np.NaN, 0.]],
                                     [[0., 2., 0., 0., 0.],
                                      [0., 2., 1., 1., 0.],
                                      [0., 0., 1., 0., 0.]]]

--- a/tests/test_mcmc_sampler.py
+++ b/tests/test_mcmc_sampler.py
@@ -117,7 +117,7 @@ def test_simple_sample():
     m = gp_model(X, z)
     m.train()
 
-    sampler = MCMCSampler(m, Cube(np.asarray([2., np.NAN])),
+    sampler = MCMCSampler(m, Cube(np.asarray([2., np.NaN])),
                           obs_uncertainty=0.1,
                           interann_uncertainty=0.,
                           repres_uncertainty=0.,


### PR DESCRIPTION
This PR addresses #2 by ensuring both the ABC and MCMC samplers can handle any NaN observations which might occur. Tf doesn't have masked arrays so any masked values get flattened to NaNs anyway. 

The ABC sampler ignores the NaNs anyway so a test and some docs are added. The MCMC sampler needed a bit more work to ensure no NaNs leak in to the likelihood calculation which would quietly break the target function. Added a test and some docs.